### PR TITLE
兼容 Medoo 更新（1.1.3 -> 1.2）

### DIFF
--- a/src/Core/Database.php
+++ b/src/Core/Database.php
@@ -34,8 +34,9 @@ namespace Kotori\Core;
 
 use Kotori\Debug\Hook;
 use Kotori\Debug\Log;
+use Medoo\Medoo as Medoo;
 
-class Database extends \medoo
+class Database extends Medoo
 {
     /**
      * SQL queries


### PR DESCRIPTION
Medoo 1.2.0 (dev-master) 将 Medoo 类的位置由 1.1.3 的 \medoo 改为了 \Medoo\Medoo，所以之前的代码：
```php
class Database extends \medoo
{
  // ...
}
```
会报找不到 \medoo 类的错误 Orz