### PR TITLE
last_query() 被重命名为 last()（还是 Medoo 更新的锅）

### DIFF
--- a/src/Core/Database.php
+++ b/src/Core/Database.php
@@ -114,16 +114,16 @@ class Database extends Medoo
     public function query($query)
     {
         array_push($this->logs, $query);
-        Log::sql($this->last_query());
-        array_push($this->queries, $this->last_query());
+        Log::sql($this->last());
+        array_push($this->queries, $this->last());
         return parent::query($query);
     }
 
     public function exec($query)
     {
         array_push($this->logs, $query);
-        Log::sql($this->last_query());
-        array_push($this->queries, $this->last_query());
+        Log::sql($this->last());
+        array_push($this->queries, $this->last());
         return parent::exec($query);
     }
 


### PR DESCRIPTION
（不得不说 Medoo 1.1.3->1.2 真的改了很多地方……短时间又没办法全都找出来所以只能在用的过程中一点一点发现…… \_(:з」∠\)_

Medoo 1.2 中将获取上一个查询的方法 last_query() 重命名为了 last()，导致 \Kotori\Core\Database 中调用了此方法的的 query() 中记录 SQL log 失败并报错(ฅ´ω`ฅ)